### PR TITLE
Use golang crypto function for encryption instead of invoking openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ A simple tool to help manage credentials. Inspired by vault.
 ## Example
 
 ```bash
+# Encrypt the secrets and save each in a file
+> mkdir -p secret_store/postgres
+> secmuxer -cmd encrypt -password p1ssw1rd > secret_store/postgres/host
+pg
+^d
+> secmuxer -cmd encrypt -password p1ssw1rd > secret_store/postgres/username
+readwrite
+^d
+> secmuxer -cmd encrypt -password p1ssw1rd > secret_store/postgres/password
+s.cr.t
+^d
 > tree ./secret_store/
 ./secret_store/
 └── postgres
@@ -40,14 +51,9 @@ EOF
 
 It's up to you how to store your secrets. They are just encrypted files. You can even version control them.
 
-## Bad thing
-
-1. The built in `sh` func is very dangerous. Only use this tool when you know the content of input.
-2. To leverage simplicity, it runs `openssl` to decrypt the file. And you cannot change the encryption algorithm.
-
 ## How did this come
 
-> Where do I put my credentials?
+- Where do I put my credentials?
 
 That problem concerns me everytime I build a personal tool. 
 I want everything to be version controlled, even the script of deployment.
@@ -55,3 +61,9 @@ And I also want my repo public.
 
 I know vault for a long time. It runs as a service and needs an server.
 But I just needs a simple cli tool. So I borrowed it's idea and made this.
+
+- How secure is the encrypted data?
+The code uses pbkdf2 (with SHA1 run 4096 times) to derive the encryption key from the password.
+The actual encryption is using 256-bit AES-GCM with random 96-bit nonces copied from cryptopasta, see:
+https://github.com/gtank/cryptopasta
+

--- a/crypt.go
+++ b/crypt.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+const saltSize = 16 // bytes
+
+// Openssl's way of derive key from passphrase is considered too weak, see:
+// https://security.stackexchange.com/questions/29106/openssl-recover-key-and-iv-by-passphrase
+// Use pbkdf2 instead see:
+// https://github.com/riverrun/comeonin/wiki/Choosing-the-password-hashing-algorithm
+func deriveKey(passphrase string, salt []byte) *[32]byte {
+	dk := pbkdf2.Key([]byte("some password"), salt, 4096, 32, sha1.New)
+	var key [32]byte
+	copy(key[:], dk)
+	return &key
+}
+
+func encrypt(plaintext []byte, passphrase string) (cipherStr string, err error) {
+	salt := make([]byte, saltSize)
+	_, err = io.ReadFull(rand.Reader, salt)
+	if err != nil {
+		return "", err
+	}
+
+	key := deriveKey(passphrase, salt)
+
+	encrypted, err := encryptWithKey(plaintext, key)
+	if err != nil {
+		return "", err
+	}
+
+	cipherBytes := make([]byte, 0, saltSize+len(encrypted))
+	cipherBytes = append(cipherBytes, salt...)
+	cipherBytes = append(cipherBytes, encrypted...)
+
+	return base64.StdEncoding.EncodeToString(cipherBytes), nil
+}
+
+func decrypt(cipherStr string, passphrase string) (plaintext []byte, err error) {
+	ciphertext, err := base64.StdEncoding.DecodeString(cipherStr)
+	if err != nil {
+		return nil, err
+	}
+	if len(ciphertext) < saltSize {
+		return nil, fmt.Errorf("Malformed encrypted data")
+	}
+
+	salt := ciphertext[:saltSize]
+	key := deriveKey(passphrase, salt)
+	return decryptWithKey(ciphertext[saltSize:], key)
+}
+
+// Encrypt and decrypt with key are copied from https://github.com/gtank/cryptopasta
+func encryptWithKey(plaintext []byte, key *[32]byte) (ciphertext []byte, err error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func decryptWithKey(ciphertext []byte, key *[32]byte) (plaintext []byte, err error) {
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, errors.New("malformed ciphertext")
+	}
+
+	return gcm.Open(nil,
+		ciphertext[:gcm.NonceSize()],
+		ciphertext[gcm.NonceSize():],
+		nil,
+	)
+}

--- a/crypt.go
+++ b/crypt.go
@@ -20,7 +20,7 @@ const saltSize = 16 // bytes
 // Use pbkdf2 instead see:
 // https://github.com/riverrun/comeonin/wiki/Choosing-the-password-hashing-algorithm
 func deriveKey(passphrase string, salt []byte) *[32]byte {
-	dk := pbkdf2.Key([]byte("some password"), salt, 4096, 32, sha1.New)
+	dk := pbkdf2.Key([]byte(passphrase), salt, 4096, 32, sha1.New)
 	var key [32]byte
 	copy(key[:], dk)
 	return &key

--- a/crypt.go
+++ b/crypt.go
@@ -20,8 +20,8 @@ const saltSize = 16 // bytes
 // Use pbkdf2 instead see:
 // https://github.com/riverrun/comeonin/wiki/Choosing-the-password-hashing-algorithm
 func deriveKey(passphrase string, salt []byte) *[32]byte {
-	dk := pbkdf2.Key([]byte(passphrase), salt, 4096, 32, sha1.New)
 	var key [32]byte
+	dk := pbkdf2.Key([]byte(passphrase), salt, 4096, len(key), sha1.New)
 	copy(key[:], dk)
 	return &key
 }

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+/*
+func TestBcrypt(t *testing.T) {
+	hash, err := bcrypt.GenerateFromPassword([]byte("test"), 14)
+	fmt.Printf("Bcrypt hash size %d\nHash: [%s]", len(hash), hash)
+	if err != nil {
+		t.Error(err)
+	}
+}
+*/
+
+func TestCrypt(t *testing.T) {
+	plaintext := "HelloWorld"
+	passphrase := "secret"
+	ciphertext, err := encrypt([]byte(plaintext), passphrase)
+	if err != nil {
+		t.Error(err)
+	}
+
+	decrypted, err := decrypt(ciphertext, passphrase)
+	if err != nil {
+		t.Error(err)
+	}
+	if plaintext != string(decrypted) {
+		t.Errorf("Decrypted text does not match original:\n[%s]\n[%s]\n", plaintext, decrypted)
+	}
+
+	fmt.Printf("Successful\n")
+}

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -5,16 +5,6 @@ import (
 	"testing"
 )
 
-/*
-func TestBcrypt(t *testing.T) {
-	hash, err := bcrypt.GenerateFromPassword([]byte("test"), 14)
-	fmt.Printf("Bcrypt hash size %d\nHash: [%s]", len(hash), hash)
-	if err != nil {
-		t.Error(err)
-	}
-}
-*/
-
 func TestCrypt(t *testing.T) {
 	plaintext := "HelloWorld"
 	passphrase := "secret"

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -20,6 +19,46 @@ func TestCrypt(t *testing.T) {
 	if plaintext != string(decrypted) {
 		t.Errorf("Decrypted text does not match original:\n[%s]\n[%s]\n", plaintext, decrypted)
 	}
+}
 
-	fmt.Printf("Successful\n")
+func TestCryptWithWrongPassphrase(t *testing.T) {
+	plaintext := "HelloWorld"
+	passphrase := "secret"
+	wrongPassphrase := "wrong"
+	ciphertext, err := encrypt([]byte(plaintext), passphrase)
+	if err != nil {
+		t.Error(err)
+	}
+
+	decrypted, err := decrypt(ciphertext, wrongPassphrase)
+	if err == nil {
+		t.Errorf("Decrypted text does not match original:\n[%s]\n[%s]\n", plaintext, decrypted)
+	}
+}
+
+func TestDeriveKey(t *testing.T) {
+	s1 := make([]byte, saltSize)
+
+	k1 := deriveKey("aaa", s1)
+	k2 := deriveKey("aaa", s1)
+
+	if *k1 != *k2 {
+		t.Errorf("Same password and salt should generate same key")
+	}
+
+	k1 = deriveKey("aaa", s1)
+	k2 = deriveKey("bbb", s1)
+
+	if *k1 == *k2 {
+		t.Errorf("Different password with same key should generate different key")
+	}
+
+	s2 := make([]byte, saltSize)
+	s2[0] = 1
+	k1 = deriveKey("aaa", s1)
+	k2 = deriveKey("aaa", s2)
+
+	if *k1 == *k2 {
+		t.Errorf("Same password with different key should generate different key")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/cirias/secmuxer
 
-require github.com/pkg/errors v0.8.0
+require (
+	github.com/pkg/errors v0.8.0
+	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 			log.Fatalln(err)
 		}
 	} else {
-		log.Fatalf("Invalid command %s, only encrypt or extract is supported.", cmd)
+		log.Fatalf("Invalid command %s, only encrypt or extract is supported.", *cmd)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,29 +1,53 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/pkg/errors"
 )
 
 func main() {
+	cmd := flag.String("cmd", "extract", "Command to execute, encrypt or extract")
 	store := flag.String("store", "", "directory of the store")
 	password := flag.String("password", "", "password used to decrypt")
 	flag.Parse()
 
-	err := execute(os.Stdin, os.Stdout, *store, *password)
-	if err != nil {
-		log.Fatalln(err)
+	if *cmd == "encrypt" {
+		err := encryptSecret(os.Stdin, os.Stdout, *password)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	} else if *cmd == "extract" {
+		err := execute(os.Stdin, os.Stdout, *store, *password)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	} else {
+		log.Fatalf("Invalid command %s, only encrypt or extract is supported.", cmd)
 	}
+}
+
+func encryptSecret(in io.Reader, out io.Writer, password string) error {
+	plain, err := ioutil.ReadAll(in)
+	if err != nil {
+		return err
+	}
+
+	encrypted, err := encrypt(bytes.TrimSpace(plain), password)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "%s", encrypted)
+	return nil
 }
 
 func execute(in io.Reader, out io.Writer, store, password string) error {
@@ -31,12 +55,15 @@ func execute(in io.Reader, out io.Writer, store, password string) error {
 		return filepath.Join(store, filename)
 	}
 	secret := func(filename string) (string, error) {
-		return sh("openssl aes-256-cbc -a -d -in %s -out - -pass pass:%s", resolve(filename), password)
+		encrypted, err := ioutil.ReadFile(resolve(filename))
+		if err != nil {
+			return "", err
+		}
+		plain, err := decrypt(string(encrypted), password)
+		return string(plain), err
 	}
 	funcMap := template.FuncMap{
-		"resolve": resolve,
-		"sh":      sh,
-		"secret":  secret,
+		"secret": secret,
 	}
 
 	bs, err := ioutil.ReadAll(in)
@@ -50,16 +77,4 @@ func execute(in io.Reader, out io.Writer, store, password string) error {
 	}
 
 	return errors.Wrap(t.Execute(out, nil), "could not execute")
-}
-
-func sh(cmdformat string, a ...interface{}) (string, error) {
-	shCmd := fmt.Sprintf(cmdformat, a...)
-	cmd := exec.Command("sh", "-c", shCmd)
-	cmd.Stderr = os.Stderr
-	stdout, err := cmd.Output()
-	if err != nil {
-		return "", errors.Wrapf(err, "could not run sh command: %s", shCmd)
-	}
-
-	return strings.TrimSpace(string(stdout)), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,19 +1,1 @@
 package main
-
-import (
-	"os"
-)
-
-func ExampleSh() {
-	f, _ := os.Open("test/sh")
-	execute(f, os.Stdout, ".", "")
-	// Output:
-	// password: password: {{ resolve "test/sh" | sh "cat %s" }}
-}
-
-func ExampleSecret() {
-	f, _ := os.Open("test/secret")
-	execute(f, os.Stdout, ".", "s9cr9t")
-	// Output:
-	// password: password
-}


### PR DESCRIPTION
Apart from mitigating the risk of directly invoking openssl using sh, and remove dependency of openssl, Openssl's way of deriving encryption key from a passphrase is not very strong, see:
https://security.stackexchange.com/questions/29106/openssl-recover-key-and-iv-by-passphrase

Since the encryption method has changed, this pull request also provides a way to encrypt secret using secmuxer. However, this would break all previously encrypted data.